### PR TITLE
Fix missing font attribute

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -19,7 +19,7 @@ in
       kitty
       kitty-themes
       # optionally, a patched font:
-      nerd-fonts.fira-code
+      nerdfonts.override { fonts = [ "FiraCode" ]; }
     ];
     programs.bash.enable = true;
 


### PR DESCRIPTION
## Summary
- fix the Nerd Font package name in the home-manager configuration

## Testing
- `bash scripts/pkgsearch.sh firefox | head -n 20` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e48ff3a288331838734b9292125b7