### PR TITLE
Update packettracer overlay with stripXml helper

### DIFF
--- a/overlays/packettracer.nix
+++ b/overlays/packettracer.nix
@@ -1,4 +1,4 @@
-## Packettracer uses some legacy shit because the updated binary looks for new tar.gz
+## Uses legacy libxml2 for Cisco Packet Tracer
 # overlays/packettracer.nix
 final: prev:
 
@@ -8,13 +8,15 @@ let
     url    = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.05.tar.gz";
     sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
   }) { inherit (prev) system; };
+
+  stripXml = list: builtins.filter (pkg: !(pkg ? pname && pkg.pname == "libxml2")) list;
 in
 {
   # patch the real build
   ciscoPacketTracer8-unwrapped = prev.ciscoPacketTracer8-unwrapped.overrideAttrs (old: {
     # drop the new libxml2, add the old one, give patchelf its path
-    buildInputs       = (old.buildInputs or []) ++ [ legacy.libxml2 ];
-    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ prev.autoPatchelfHook ];
+    buildInputs       = stripXml (old.buildInputs or []) ++ [ legacy.libxml2 ];
+    nativeBuildInputs = stripXml (old.nativeBuildInputs or []) ++ [ prev.autoPatchelfHook ];
     autoPatchelfSearchPath = [ "${legacy.libxml2}/lib" ];
   });
 }


### PR DESCRIPTION
## Summary
- modernize Packet Tracer overlay
- add `stripXml` to filter libxml2
- apply `stripXml` in build phases
- keep the legacy libxml2 search path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e510b7e848331b52678fca21e8c26